### PR TITLE
closes #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const Product = require('./components/Product');
+const React = require('react');
+const ReactDOM = require('react-dom');
 
 ReactDOM.render(
   <Product name="Dunder Mifflin" producer="PaperCo" color="white" weight={210} />,


### PR DESCRIPTION
adds 
```
const React = require('react');
const ReactDOM = require('react-dom);
```
to the top of `index.js` to remove reference error when viewing Product component in browser (after running `npm run bundle`